### PR TITLE
build binary for Apple M1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,10 @@ before_install:
   - yarn --version
 script:
   - make
+  - if [ $TRAVIS_OS_NAME == "osx" ]; then
+      CFLAGS="-Wno-implicit-function-declaration" CPPFLAGS="-DPNG_ARM_NEON_OPT=0" yarn prebuild --arch=arm64;
+      ARCH="arm64" yarn postbuild;
+    fi
 after_script:
   - "cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
 cache: yarn

--- a/scripts/file-name.js
+++ b/scripts/file-name.js
@@ -1,6 +1,6 @@
 const path = require("path");
 
-const suffix = `${process.platform}-${process.arch}-${process.versions.modules}`;
+const suffix = `${process.platform}-${process.env.ARCH || process.arch}-${process.versions.modules}`;
 const baseName = `node-libpng-${suffix}.node`;
 const qualifiedName = path.resolve(__dirname, "..", baseName);
 


### PR DESCRIPTION
 I was able to cross-compile for the M1 chip from an Intel machine with these commands:

```sh
CFLAGS="-Wno-implicit-function-declaration" CPPFLAGS="-DPNG_ARM_NEON_OPT=0" yarn prebuild --arch=arm64
ARCH="arm64" yarn postbuild

> file node-libpng-darwin-arm64-83.node
node-libpng-darwin-arm64-83.node: Mach-O 64-bit bundle arm64
```

I airdropped the file to an M1 computer and all tests passed.

Solves #45